### PR TITLE
Fjernet kode som hopper over saksnummersteget hvis ingen jounalpost

### DIFF
--- a/src/main/java/no/nav/familie/ks/mottak/app/mottak/HentJournalpostService.java
+++ b/src/main/java/no/nav/familie/ks/mottak/app/mottak/HentJournalpostService.java
@@ -13,7 +13,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
@@ -51,19 +50,10 @@ public class HentJournalpostService {
     public void hentJournalpostId(String søknadId, String callId) {
         Soknad søknad = hentSoknad(søknadId);
 
-        try {
-            Optional<String> journalpostId = hentFraUrl(oppslagUrl + "/journalpost/kanalreferanseid/%s", callId);
-            søknad.setJournalpostID(journalpostId.orElseThrow(() -> new RuntimeException("Finner ikke journalpost for kanalReferanseId=" + callId + ", søknadId=" + søknadId)));
-            søknadRepository.save(søknad);
-        } catch (RestClientException e) { //FIXME slett try catch block når CallId er propargert fra web til joark
-            LOG.warn("Midlertidig ignorerer feil ved henting av journalpostId ved bruk av CallId");
-        }
-    }
+        Optional<String> journalpostId = hentFraUrl(oppslagUrl + "/journalpost/kanalreferanseid/%s", callId);
+        søknad.setJournalpostID(journalpostId.orElseThrow(() -> new RuntimeException("Finner ikke journalpost for kanalReferanseId=" + callId + ", søknadId=" + søknadId)));
+        søknadRepository.save(søknad);
 
-    @Deprecated(forRemoval = true) ////FIXME slett når CallId er propargert fra web til joark
-    public boolean harJournalpostId(String søknadId) {
-        Soknad søknad = hentSoknad(søknadId);
-        return søknad.getJournalpostID() != null;
     }
 
     private Soknad hentSoknad(String søknadId) {

--- a/src/main/java/no/nav/familie/ks/mottak/app/task/HentJournalpostIdFraJoarkTask.java
+++ b/src/main/java/no/nav/familie/ks/mottak/app/task/HentJournalpostIdFraJoarkTask.java
@@ -32,14 +32,9 @@ public class HentJournalpostIdFraJoarkTask implements AsyncTask {
     }
 
     @Override
-    public void onCompletion(Task task){
-        if (hentJournalpostService.harJournalpostId(task.getPayload())) {
-            LocalDateTime startTidspunkt = LocalDateTime.now().plusMinutes(15);
-            Task nesteTask = Task.nyTaskMedStartFremITid(HentSaksnummerFraJoarkTask.HENT_SAKSNUMMER_FRA_JOARK,task.getPayload(), startTidspunkt);
-            taskRepository.save(nesteTask);
-        } else {
-            Task nesteTask = Task.nyTask(SendSøknadTilSakTask.SEND_SØKNAD_TIL_SAK,task.getPayload()); //FIXME Når callid er propagert rett fra web til joark så kan vi sende bare til HentSaksnummerFraJoarkTask
-            taskRepository.save(nesteTask);
-        }
+    public void onCompletion(Task task) {
+        LocalDateTime startTidspunkt = LocalDateTime.now().plusMinutes(15);
+        Task nesteTask = Task.nyTaskMedStartFremITid(HentSaksnummerFraJoarkTask.HENT_SAKSNUMMER_FRA_JOARK, task.getPayload(), startTidspunkt);
+        taskRepository.save(nesteTask);
     }
 }


### PR DESCRIPTION

- CallId er tilgjenglig hele veien nå. Kode ikke lenger nødvendig.