### PR TITLE
lagre journalpostId og saksnummer på metadata

### DIFF
--- a/src/main/java/no/nav/familie/ks/mottak/app/mottak/HentJournalpostService.java
+++ b/src/main/java/no/nav/familie/ks/mottak/app/mottak/HentJournalpostService.java
@@ -53,7 +53,7 @@ public class HentJournalpostService extends BaseService {
         }
     }
 
-    public void hentSaksnummer(String søknadId) {
+    public String hentSaksnummer(String søknadId) {
         Soknad søknad = hentSoknad(søknadId);
         String journalpostID = søknad.getJournalpostID();
         Optional<String> saksnummer =
@@ -62,6 +62,7 @@ public class HentJournalpostService extends BaseService {
         søknad.setSaksnummer(saksnummer.orElseThrow(() -> new RuntimeException(
             "Finner ikke saksnummer for journalpostId=" + journalpostID + ", søknadId=" + søknadId)));
         søknadService.lagreSøknad(søknad);
+        return saksnummer.get();
     }
 
     private Optional<String> hentFraUrl(String urlformat, String fieldName, Object... searchParams) {

--- a/src/main/java/no/nav/familie/ks/mottak/app/mottak/JournalføringService.java
+++ b/src/main/java/no/nav/familie/ks/mottak/app/mottak/JournalføringService.java
@@ -42,7 +42,7 @@ public class JournalføringService extends BaseService {
         this.søknadService = søknadService;
     }
 
-    public void journalførSøknad(String søknadId) {
+    public String journalførSøknad(String søknadId) {
         Soknad søknad = søknadService.hentSoknad(søknadId);
         List<Dokument> dokumenter = søknad.getVedlegg().stream()
                                           .map(this::tilDokument)
@@ -52,6 +52,7 @@ public class JournalføringService extends BaseService {
         søknad.setJournalpostID(journalpostID);
         søknad.getVedlegg().clear();
         søknadService.lagreSøknad(søknad);
+        return journalpostID;
     }
 
     private ArkiverDokumentResponse send(ArkiverDokumentRequest arkiverDokumentRequest) {

--- a/src/main/java/no/nav/familie/ks/mottak/app/task/HentSaksnummerFraJoarkTask.java
+++ b/src/main/java/no/nav/familie/ks/mottak/app/task/HentSaksnummerFraJoarkTask.java
@@ -33,7 +33,9 @@ public class HentSaksnummerFraJoarkTask implements AsyncTask {
     @Override
     public void doTask(Task task) {
         try {
-            hentJournalpostService.hentSaksnummer(task.getPayload());
+            String saksnummer = hentJournalpostService.hentSaksnummer(task.getPayload());
+            task.getMetadata().put("saksnummer", saksnummer);
+            taskRepository.saveAndFlush(task);
         } catch (HttpClientErrorException.NotFound notFound) {
             LOG.info("Hent saksnummer returnerte 404 responsebody={}", notFound.getResponseBodyAsString());
             task.setTriggerTid(LocalDateTime.now().plusMinutes(15));
@@ -45,6 +47,7 @@ public class HentSaksnummerFraJoarkTask implements AsyncTask {
     @Override
     public void onCompletion(Task task) {
         Task nesteTask = Task.nyTask(SendSøknadTilSakTask.SEND_SØKNAD_TIL_SAK, task.getPayload());
+        nesteTask.getMetadata().putAll(task.getMetadata());
         taskRepository.save(nesteTask);
     }
 }

--- a/src/main/java/no/nav/familie/ks/mottak/app/task/JournalførSøknadTask.java
+++ b/src/main/java/no/nav/familie/ks/mottak/app/task/JournalførSøknadTask.java
@@ -28,12 +28,15 @@ public class JournalførSøknadTask implements AsyncTask {
 
     @Override
     public void doTask(Task task) {
-        journalføringService.journalførSøknad(task.getPayload());
+        String journlpostId = journalføringService.journalførSøknad(task.getPayload());
+        task.getMetadata().put("journalpostID", journlpostId);
+        taskRepository.saveAndFlush(task);
     }
 
     @Override
-    public void onCompletion(Task task){
-        Task nesteTask = Task.nyTask(HentSaksnummerFraJoarkTask.HENT_SAKSNUMMER_FRA_JOARK,task.getPayload());
+    public void onCompletion(Task task) {
+        Task nesteTask = Task.nyTask(HentSaksnummerFraJoarkTask.HENT_SAKSNUMMER_FRA_JOARK, task.getPayload());
+        nesteTask.getMetadata().putAll(task.getMetadata());
         taskRepository.save(nesteTask);
     }
- }
+}

--- a/src/main/java/no/nav/familie/ks/mottak/app/task/SendSøknadTilSakTask.java
+++ b/src/main/java/no/nav/familie/ks/mottak/app/task/SendSøknadTilSakTask.java
@@ -29,7 +29,9 @@ public class SendSøknadTilSakTask implements AsyncTask {
     }
 
     @Override
-    public void onCompletion(Task task){
-        taskRepository.save(Task.nyTask(SendMeldingTilDittNavTask.SEND_MELDING_TIL_DITT_NAV, task.getPayload()));
+    public void onCompletion(Task task) {
+        Task nesteTask = Task.nyTask(SendMeldingTilDittNavTask.SEND_MELDING_TIL_DITT_NAV, task.getPayload());
+        nesteTask.getMetadata().putAll(task.getMetadata());
+        taskRepository.save(nesteTask);
     }
 }


### PR DESCRIPTION
Lagrer journalpostId og saksnummer på metadata også.  Når man tar i bruk felles-prossesering, så slettes journalpostId og saksnummer fra Soknad.
